### PR TITLE
Fix incorrect capitalization on weapon names

### DIFF
--- a/src/data/weapons/assaultRifles.js
+++ b/src/data/weapons/assaultRifles.js
@@ -6,8 +6,8 @@ const weapons = [
   { name: 'AK-74' },
   { name: 'AMES 85' },
   { name: 'GPR 91' },
-  { name: 'MODEL L' },
-  { name: 'GOBLIN MK 2' },
+  { name: 'Model L' },
+  { name: 'Goblin Mk2' },
   { name: 'AS VAL' },
 ]
 

--- a/src/data/weapons/subMachineGuns.js
+++ b/src/data/weapons/subMachineGuns.js
@@ -4,10 +4,10 @@ import defaultProgress from '@/data/defaults/progress'
 const weapons = [
   { name: 'C9' },
   { name: 'KSV' },
-  { name: 'TANTO .22' },
+  { name: 'Tanto .22' },
   { name: 'PP-919' },
   { name: 'Jackal PDW' },
-  { name: 'KOMPAKT 92' },
+  { name: 'Kompakt 92' },
 ]
 
 export default weapons.map((weapon) => ({


### PR DESCRIPTION
Fixes incorrect capitalization on weapon names

Note: Camo progression will be lost, but should be fine since it's early days of the tracker.