### PR TITLE
Fixed kill / critical count for all weapon categories in zombies

### DIFF
--- a/src/data/requirements/weapons/handguns.js
+++ b/src/data/requirements/weapons/handguns.js
@@ -97,15 +97,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'critical_kills' },
-        'Woodland': { amount: 100, type: 'critical_kills' },
-        'Savanna': { amount: 150, type: 'critical_kills' },
-        'Splinter': { amount: 200, type: 'critical_kills' },
-        'Moss': { amount: 300, type: 'critical_kills' },
-        'Shade': { amount: 400, type: 'critical_kills' },
-        'Digital': { amount: 500, type: 'critical_kills' },
-        'Tide': { amount: 750, type: 'critical_kills' },
-        'Red Tiger': { amount: 1000, type: 'critical_kills' },
+        'Granite': { amount: 100, type: 'critical_kills' },
+        'Woodland': { amount: 200, type: 'critical_kills' },
+        'Savanna': { amount: 300, type: 'critical_kills' },
+        'Splinter': { amount: 400, type: 'critical_kills' },
+        'Moss': { amount: 600, type: 'critical_kills' },
+        'Shade': { amount: 800, type: 'critical_kills' },
+        'Digital': { amount: 1000, type: 'critical_kills' },
+        'Tide': { amount: 1500, type: 'critical_kills' },
+        'Red Tiger': { amount: 2000, type: 'critical_kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/launchers.js
+++ b/src/data/requirements/weapons/launchers.js
@@ -63,15 +63,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'kills' },
-        'Woodland': { amount: 100, type: 'kills' },
-        'Savanna': { amount: 150, type: 'kills' },
-        'Splinter': { amount: 200, type: 'kills' },
-        'Moss': { amount: 300, type: 'kills' },
-        'Shade': { amount: 400, type: 'kills' },
-        'Digital': { amount: 500, type: 'kills' },
-        'Tide': { amount: 750, type: 'kills' },
-        'Red Tiger': { amount: 1000, type: 'kills' },
+        'Granite': { amount: 100, type: 'kills' },
+        'Woodland': { amount: 200, type: 'kills' },
+        'Savanna': { amount: 300, type: 'kills' },
+        'Splinter': { amount: 400, type: 'kills' },
+        'Moss': { amount: 600, type: 'kills' },
+        'Shade': { amount: 800, type: 'kills' },
+        'Digital': { amount: 1000, type: 'kills' },
+        'Tide': { amount: 1500, type: 'kills' },
+        'Red Tiger': { amount: 2000, type: 'kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/lightMachineGuns.js
+++ b/src/data/requirements/weapons/lightMachineGuns.js
@@ -80,15 +80,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'critical_kills' },
-        'Woodland': { amount: 100, type: 'critical_kills' },
-        'Savanna': { amount: 150, type: 'critical_kills' },
-        'Splinter': { amount: 200, type: 'critical_kills' },
-        'Moss': { amount: 300, type: 'critical_kills' },
-        'Shade': { amount: 400, type: 'critical_kills' },
-        'Digital': { amount: 500, type: 'critical_kills' },
-        'Tide': { amount: 750, type: 'critical_kills' },
-        'Red Tiger': { amount: 1000, type: 'critical_kills' },
+        'Granite': { amount: 100, type: 'critical_kills' },
+        'Woodland': { amount: 200, type: 'critical_kills' },
+        'Savanna': { amount: 300, type: 'critical_kills' },
+        'Splinter': { amount: 400, type: 'critical_kills' },
+        'Moss': { amount: 600, type: 'critical_kills' },
+        'Shade': { amount: 800, type: 'critical_kills' },
+        'Digital': { amount: 1000, type: 'critical_kills' },
+        'Tide': { amount: 1500, type: 'critical_kills' },
+        'Red Tiger': { amount: 2000, type: 'critical_kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/marksmanRifles.js
+++ b/src/data/requirements/weapons/marksmanRifles.js
@@ -97,15 +97,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'critical_kills' },
-        'Woodland': { amount: 100, type: 'critical_kills' },
-        'Savanna': { amount: 150, type: 'critical_kills' },
-        'Splinter': { amount: 200, type: 'critical_kills' },
-        'Moss': { amount: 300, type: 'critical_kills' },
-        'Shade': { amount: 400, type: 'critical_kills' },
-        'Digital': { amount: 500, type: 'critical_kills' },
-        'Tide': { amount: 750, type: 'critical_kills' },
-        'Red Tiger': { amount: 1000, type: 'critical_kills' },
+        'Granite': { amount: 100, type: 'critical_kills' },
+        'Woodland': { amount: 200, type: 'critical_kills' },
+        'Savanna': { amount: 300, type: 'critical_kills' },
+        'Splinter': { amount: 400, type: 'critical_kills' },
+        'Moss': { amount: 600, type: 'critical_kills' },
+        'Shade': { amount: 800, type: 'critical_kills' },
+        'Digital': { amount: 1000, type: 'critical_kills' },
+        'Tide': { amount: 1500, type: 'critical_kills' },
+        'Red Tiger': { amount: 2000, type: 'critical_kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/melee.js
+++ b/src/data/requirements/weapons/melee.js
@@ -63,15 +63,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'kills' },
-        'Woodland': { amount: 100, type: 'kills' },
-        'Savanna': { amount: 150, type: 'kills' },
-        'Splinter': { amount: 200, type: 'kills' },
-        'Moss': { amount: 300, type: 'kills' },
-        'Shade': { amount: 400, type: 'kills' },
-        'Digital': { amount: 500, type: 'kills' },
-        'Tide': { amount: 750, type: 'kills' },
-        'Red Tiger': { amount: 1000, type: 'kills' },
+        'Granite': { amount: 100, type: 'kills' },
+        'Woodland': { amount: 200, type: 'kills' },
+        'Savanna': { amount: 300, type: 'kills' },
+        'Splinter': { amount: 400, type: 'kills' },
+        'Moss': { amount: 600, type: 'kills' },
+        'Shade': { amount: 800, type: 'kills' },
+        'Digital': { amount: 1000, type: 'kills' },
+        'Tide': { amount: 1500, type: 'kills' },
+        'Red Tiger': { amount: 2000, type: 'kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/shotguns.js
+++ b/src/data/requirements/weapons/shotguns.js
@@ -63,15 +63,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'critical_kills' },
-        'Woodland': { amount: 100, type: 'critical_kills' },
-        'Savanna': { amount: 150, type: 'critical_kills' },
-        'Splinter': { amount: 200, type: 'critical_kills' },
-        'Moss': { amount: 300, type: 'critical_kills' },
-        'Shade': { amount: 400, type: 'critical_kills' },
-        'Digital': { amount: 500, type: 'critical_kills' },
-        'Tide': { amount: 750, type: 'critical_kills' },
-        'Red Tiger': { amount: 1000, type: 'critical_kills' },
+        'Granite': { amount: 100, type: 'critical_kills' },
+        'Woodland': { amount: 200, type: 'critical_kills' },
+        'Savanna': { amount: 300, type: 'critical_kills' },
+        'Splinter': { amount: 400, type: 'critical_kills' },
+        'Moss': { amount: 600, type: 'critical_kills' },
+        'Shade': { amount: 800, type: 'critical_kills' },
+        'Digital': { amount: 1000, type: 'critical_kills' },
+        'Tide': { amount: 1500, type: 'critical_kills' },
+        'Red Tiger': { amount: 2000, type: 'critical_kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/sniperRifles.js
+++ b/src/data/requirements/weapons/sniperRifles.js
@@ -80,15 +80,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'critical_kills' },
-        'Woodland': { amount: 100, type: 'critical_kills' },
-        'Savanna': { amount: 150, type: 'critical_kills' },
-        'Splinter': { amount: 200, type: 'critical_kills' },
-        'Moss': { amount: 300, type: 'critical_kills' },
-        'Shade': { amount: 400, type: 'critical_kills' },
-        'Digital': { amount: 500, type: 'critical_kills' },
-        'Tide': { amount: 750, type: 'critical_kills' },
-        'Red Tiger': { amount: 1000, type: 'critical_kills' },
+        'Granite': { amount: 100, type: 'critical_kills' },
+        'Woodland': { amount: 200, type: 'critical_kills' },
+        'Savanna': { amount: 300, type: 'critical_kills' },
+        'Splinter': { amount: 400, type: 'critical_kills' },
+        'Moss': { amount: 600, type: 'critical_kills' },
+        'Shade': { amount: 800, type: 'critical_kills' },
+        'Digital': { amount: 1000, type: 'critical_kills' },
+        'Tide': { amount: 1500, type: 'critical_kills' },
+        'Red Tiger': { amount: 2000, type: 'critical_kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,

--- a/src/data/requirements/weapons/subMachineGuns.js
+++ b/src/data/requirements/weapons/subMachineGuns.js
@@ -131,15 +131,15 @@ export default {
 
       zombies: {
         // Military
-        'Granite': { amount: 50, type: 'critical_kills' },
-        'Woodland': { amount: 100, type: 'critical_kills' },
-        'Savanna': { amount: 150, type: 'critical_kills' },
-        'Splinter': { amount: 200, type: 'critical_kills' },
-        'Moss': { amount: 300, type: 'critical_kills' },
-        'Shade': { amount: 400, type: 'critical_kills' },
-        'Digital': { amount: 500, type: 'critical_kills' },
-        'Tide': { amount: 750, type: 'critical_kills' },
-        'Red Tiger': { amount: 1000, type: 'critical_kills' },
+        'Granite': { amount: 100, type: 'critical_kills' },
+        'Woodland': { amount: 200, type: 'critical_kills' },
+        'Savanna': { amount: 300, type: 'critical_kills' },
+        'Splinter': { amount: 400, type: 'critical_kills' },
+        'Moss': { amount: 600, type: 'critical_kills' },
+        'Shade': { amount: 800, type: 'critical_kills' },
+        'Digital': { amount: 1000, type: 'critical_kills' },
+        'Tide': { amount: 1500, type: 'critical_kills' },
+        'Red Tiger': { amount: 2000, type: 'critical_kills' },
 
         // Special
         ...specialCamouflages[weapon]?.zombies,


### PR DESCRIPTION
Previously, only the "Assault Rifle" category had the correct critical kills count. Now, all military camos should be accurate.