### PR TITLE
fix: rename "Numbus" to "Nimbus" in sniperRifles.js

### DIFF
--- a/src/data/requirements/weapons/sniperRifles.js
+++ b/src/data/requirements/weapons/sniperRifles.js
@@ -38,7 +38,7 @@ const specialCamouflages = {
   'LR 7.62': {
     multiplayer: {
       Chaparral: { amount: 30, type: 'one_shot_kills' },
-      Numbus: { amount: 15, type: 'longshot_kills' },
+      Nimbus: { amount: 15, type: 'longshot_kills' },
     },
 
     zombies: {


### PR DESCRIPTION
changes Numbus to Nimbus in the sniperRifles to match the change in pr #14, as it causes unexpected behaviour when completing camos on that weapon