### PR TITLE
Fixed kills without reloading for GPMG-7 & XMG

### DIFF
--- a/src/data/requirements/weapons/lightMachineGuns.js
+++ b/src/data/requirements/weapons/lightMachineGuns.js
@@ -25,7 +25,7 @@ const specialCamouflages = {
     },
 
     zombies: {
-      'Hiss': { amount: 10, type: 'kills_without_reloading' },
+      'Hiss': { amount: 10, type: 'kills_without_reloading', times: 15 },
       'Acid Slide': { amount: 300, type: 'kills_with_brain_rot_equipped' },
     },
 
@@ -43,7 +43,7 @@ const specialCamouflages = {
 
     zombies: {
       'Impressionist': { amount: 300, type: 'point_blank_kills' },
-      'Other World': { amount: 10, type: 'kills_without_reloading' },
+      'Other World': { amount: 10, type: 'kills_without_reloading', times: 15 },
     },
 
     warzone: {


### PR DESCRIPTION
This is a fix for #18 but fixes the same bug for the GPMG-7's Other World camo as well