### PR TITLE
Fixing favorite toggle for multiplayer

### DIFF
--- a/src/components/WeaponComponent.vue
+++ b/src/components/WeaponComponent.vue
@@ -118,7 +118,6 @@
       icon-style="solid"
       size="25"
       @click="
-      console.log(`DEBUGGER ${progressKey}`);
         toggleFavorite({
           type: progressKey === 'progress' | progressKey === 'multiplayer' ? 'weapons' : progressKey,
           name: weapon.name,

--- a/src/components/WeaponComponent.vue
+++ b/src/components/WeaponComponent.vue
@@ -118,10 +118,11 @@
       icon-style="solid"
       size="25"
       @click="
+      console.log(`DEBUGGER ${progressKey}`);
         toggleFavorite({
-          type: progressKey === 'progress' ? 'weapons' : progressKey,
+          type: progressKey === 'progress' | progressKey === 'multiplayer' ? 'weapons' : progressKey,
           name: weapon.name,
-        })
+        });
       "
       v-tippy="{
         content: $t('filters.toggle_favorite', {
@@ -178,7 +179,7 @@ export default {
 
     isFavorite() {
       if (!this.store) return false
-      let type = this.progressKey === 'progress' ? 'weapons' : this.progressKey
+      let type = this.progressKey === 'progress' | this.progressKey === 'multiplayer' ? 'weapons' : this.progressKey
       return this.store.isFavorite(type, this.weapon.name)
     },
 


### PR DESCRIPTION
This is in regard to #13.
The progress key used when favoriting weapons was `"multiplayer"` this is incorrect as the favorites object does not have a key by that name. It seems to me it should instead have been `"weapons"`. This is now checked for and fixed both when favoriting a gun and when checking if a given gun is favorited.
