### PR TITLE
Add S2 Weapons in Preperation

### DIFF
--- a/src/data/camouflageOrder.js
+++ b/src/data/camouflageOrder.js
@@ -75,6 +75,8 @@ const specialOrder = [
   'Sunny Splash',
   'Crowsbane',
 
+  //Cypher 091
+
   // C9
   'Heatwave',
   'Panther',
@@ -135,6 +137,8 @@ const specialOrder = [
   'Impressionist',
   'Other World',
 
+  // Feng 82
+
   // Marine SP
   'Blueberry Lime',
   'Chromed Out',
@@ -176,6 +180,8 @@ const specialOrder = [
   'Cobalt',
   'Furybloom',
   'Manta',
+
+  // TR2
 
   // LW3A1 Frostline
   'Copper',
@@ -259,7 +265,7 @@ const specialOrder = [
   'Nebulon',
   'Enchanted',
   'Starsync',
-  'Tempt Fate'
+  'Tempt Fate',
 ]
 
 const masteryOrder = [

--- a/src/data/requirements/weapons/assaultRifles.js
+++ b/src/data/requirements/weapons/assaultRifles.js
@@ -137,6 +137,22 @@ const specialCamouflages = {
     },
   },
 
+  'Cypher 091': {
+    multiplayer: {
+      '?': null,
+      '??': null,
+    },
+
+    zombies: {
+      '?': null,
+      '??': null,
+    },
+
+    warzone: {
+      '?': null,
+      '??': null,
+    },
+  },
 }
 
 export default {

--- a/src/data/requirements/weapons/lightMachineGuns.js
+++ b/src/data/requirements/weapons/lightMachineGuns.js
@@ -51,6 +51,23 @@ const specialCamouflages = {
       '??': null,
     },
   },
+
+  'Feng 82': {
+    multiplayer: {
+      '?': null,
+      '??': null,
+    },
+
+    zombies: {
+      '?': null,
+      '??': null,
+    },
+
+    warzone: {
+      '?': null,
+      '??': null,
+    },
+  },
 }
 
 export default {

--- a/src/data/requirements/weapons/marksmanRifles.js
+++ b/src/data/requirements/weapons/marksmanRifles.js
@@ -68,6 +68,23 @@ const specialCamouflages = {
       '??': null,
     },
   },
+
+  'TR2': {
+    multiplayer: {
+      '?': null,
+      '??': null,
+    },
+
+    zombies: {
+      '?': null,
+      '??': null,
+    },
+
+    warzone: {
+      '?': null,
+      '??': null,
+    },
+  },
 }
 
 export default {

--- a/src/data/requirements/weapons/subMachineGuns.js
+++ b/src/data/requirements/weapons/subMachineGuns.js
@@ -119,6 +119,23 @@ const specialCamouflages = {
       'Dreamcurrent': { amount: 3, times: 5, type: 'kills_sm' },
     },
   },
+
+  'PPSh-41': {
+    multiplayer: {
+      '?': null,
+      '??': null,
+    },
+
+    zombies: {
+      '?': null,
+      '??': null,
+    },
+
+    warzone: {
+      '?': null,
+      '??': null,
+    },
+  },
 }
 
 export default {

--- a/src/data/weapons/assaultRifles.js
+++ b/src/data/weapons/assaultRifles.js
@@ -1,2 +1,2 @@
 // The order of the weapons in this array is the order they will appear in the app
-export default ['XM4', 'AK-74', 'AMES 85', 'GPR 91', 'Model L', 'Goblin Mk2', 'AS VAL', 'Krig C']
+export default ['XM4', 'AK-74', 'AMES 85', 'GPR 91', 'Model L', 'Goblin Mk2', 'AS VAL', 'Krig C', 'Cypher 091']

--- a/src/data/weapons/lightMachineGuns.js
+++ b/src/data/weapons/lightMachineGuns.js
@@ -1,2 +1,2 @@
 // The order of the weapons in this array is the order they will appear in the app
-export default ['PU-21', 'XMG', 'GPMG-7']
+export default ['PU-21', 'XMG', 'GPMG-7', 'Feng 82']

--- a/src/data/weapons/marksmanRifles.js
+++ b/src/data/weapons/marksmanRifles.js
@@ -1,3 +1,3 @@
 // The order of the weapons in this array is the order they will appear in the app
 
-export default ['SWAT 5.56', 'Tsarkov 7.62', 'AEK-973', 'DM-10']
+export default ['SWAT 5.56', 'Tsarkov 7.62', 'AEK-973', 'DM-10', 'TR2']

--- a/src/data/weapons/subMachineGuns.js
+++ b/src/data/weapons/subMachineGuns.js
@@ -1,2 +1,2 @@
 // The order of the weapons in this array is the order they will appear in the app
-export default ['C9', 'KSV', 'Tanto .22', 'PP-919', 'Jackal PDW', 'Kompakt 92', 'Saug']
+export default ['C9', 'KSV', 'Tanto .22', 'PP-919', 'Jackal PDW', 'Kompakt 92', 'Saug', 'PPSh-41']


### PR DESCRIPTION
Sorry if you've already done this but figured I may as well try and save you the hassle of adding them in.
Adds the:
- PPSh-41
- Cypher 091
- Feng 82
- TR2
From the most recent [blog post](https://www.callofduty.com/blog/2025/01/call-of-duty-black-ops-6-warzone-zombies-season-two-maps-modes-announcement#Weapons)

![image](https://github.com/user-attachments/assets/6bb9cde2-9ca1-4920-bd1e-8dacaca2031c)
![image](https://github.com/user-attachments/assets/61465e6b-417a-4d4d-96c8-85a30238b83e)
